### PR TITLE
Update controles_ventana.cpp

### DIFF
--- a/controles_ventana.cpp
+++ b/controles_ventana.cpp
@@ -34,6 +34,13 @@ void ventana_controles::resizeEvent(QResizeEvent *event)
 
     // Redimensionar manualmente el QLabel para que se ajuste al nuevo tamaño de la ventana
     QSize newSize = this->size() - QSize(60, 60); // Restar los márgenes (30 píxeles en cada lado)
+
+    // Asegurar un tamaño mínimo para evitar valores negativos o demasiado pequeños
+    int minWidth = 50;
+    int minHeight = 50;
+    newSize.setWidth(std::max(newSize.width(), minWidth));
+    newSize.setHeight(std::max(newSize.height(), minHeight));
+
     ui->l_img1->resize(newSize);
 
     // Escalar la imagen para que se ajuste al nuevo tamaño del QLabel


### PR DESCRIPTION
A potential edge case to consider is when the window is resized to a very small size, possibly making newSize negative or too small to display the image properly.  This can be  handled  by ensuring a minimum size for newSize before applying it: